### PR TITLE
Use mpfr module from runtime

### DIFF
--- a/io.gitlab.leesonwai.Sums.json
+++ b/io.gitlab.leesonwai.Sums.json
@@ -23,16 +23,6 @@
   ],
   "modules" : [
     {
-      "name" : "mpfr",
-      "sources" : [
-        {
-          "type" : "archive",
-          "url" : "https://ftp.gnu.org/gnu/mpfr/mpfr-4.2.2.tar.xz",
-          "sha256" : "b67ba0383ef7e8a8563734e2e889ef5ec3c3b898a01d00fa0a6869ad81c6ce01"
-        }
-      ]
-    },
-    {
       "name" : "sums",
       "buildsystem" : "meson",
       "builddir" : true,


### PR DESCRIPTION
GNOME runtime version **49** (based on the Freedesktop runtime version **25.08**) appears to provide the **mpfr** module. 

In most cases, you don't need to build this module separately, unless your project requires a specific version or a custom configuration. 

Fixes: https://github.com/flathub/io.gitlab.leesonwai.Sums/issues/12